### PR TITLE
Adding the containalbe element title array to the mediator Definition

### DIFF
--- a/modules/sequence-diagram-editor/js/diagram/diagram-view.js
+++ b/modules/sequence-diagram-editor/js/diagram/diagram-view.js
@@ -936,16 +936,13 @@ var Diagrams = (function (diagrams) {
                     );
                     txt.selectedNode.addChild(processor);
 
-                    if (processor.type == "TryBlockMediator") {
-                        var containableProcessorElem1 = new SequenceD.Models.ContainableProcessorElement(lifeLineOptions);
-                        containableProcessorElem1.set('title', "Try");
-                        containableProcessorElem1.parent(processor);
-                        processor.containableProcessorElements().add(containableProcessorElem1);
-
-                        var containableProcessorElem2 = new SequenceD.Models.ContainableProcessorElement(lifeLineOptions);
-                        containableProcessorElem2.set('title', "Catch");
-                        containableProcessorElem2.parent(processor);
-                        processor.containableProcessorElements().add(containableProcessorElem2);
+                    if (Processors.flowControllers[id].type == "ComplexProcessor") {
+                        (Processors.flowControllers[id].containableElements).forEach(function(elm) {
+                            var containableProcessorElem = new SequenceD.Models.ContainableProcessorElement(lifeLineOptions);
+                            containableProcessorElem.set('title', elm);
+                            containableProcessorElem.parent(processor);
+                            processor.containableProcessorElements().add(containableProcessorElem);
+                        });
                     }
 
 

--- a/modules/sequence-diagram-editor/js/processors/definitions/flow_controllers/try_block_mediator.js
+++ b/modules/sequence-diagram-editor/js/processors/definitions/flow_controllers/try_block_mediator.js
@@ -27,6 +27,7 @@ var Processors = (function (processors) {
         icon: "images/tool-icons/tryblock.svg",
         colour : "#998844",
         type : "ComplexProcessor",
+        containableElements: ["Try", "Catch"],
         dragCursorOffset : { left: 50, top: -5 },
         createCloneCallback : function(view){
             function cloneCallBack() {


### PR DESCRIPTION
With this PR, we are adding the containable element titles as an array to the mediator definition. if we have a complex processor like try catch, there are several containable elements used to compose the particular mediator. What ever the complexProcessor typed mediator is, we have to provide an array of titles (If for try catch, provide ["Try", "Catch"] as for the two containable elements initially). When creating the processor model we will iterate on this array and will create the mediator. This is common for all the complex mediators. Will generalize the containable processor drawing.