### PR TITLE
Adding event manager to handle visual validations

### DIFF
--- a/modules/sequence-diagram-editor/css/diagram/diagram-tool-bar.css
+++ b/modules/sequence-diagram-editor/css/diagram/diagram-tool-bar.css
@@ -71,3 +71,8 @@
     display : block;
     margin : auto;
 }
+.tool-validator{
+    height: 40px;
+    color: darkred;
+    display:none;
+}

--- a/modules/sequence-diagram-editor/js/app.js
+++ b/modules/sequence-diagram-editor/js/app.js
@@ -18,6 +18,7 @@
 
 
 
+var eventManager = new Diagrams.Models.EventManager({});
 var lifeLineOptions = {};
 lifeLineOptions.class = "lifeline";
 // Lifeline rectangle options
@@ -213,6 +214,5 @@ tab.setSelectedTab();
 var preview = new Diagrams.Views.DiagramOutlineView({mainView: currentView1});
 preview.render();
 tab.preview(preview);
-
 
 

--- a/modules/sequence-diagram-editor/js/diagram/diagram-model.js
+++ b/modules/sequence-diagram-editor/js/diagram/diagram-model.js
@@ -596,6 +596,54 @@ var Diagrams = (function (diagrams) {
             model: Diagram
 
         });
+    var EventManager = Backbone.Model.extend(
+        /** @lends Eventmanager.prototype */
+        {
+            idAttribute: this.cid,
+            modelName: "EventManager",
+            /**
+             * @augments Backbone.Model
+             * @constructs
+             * @class Handles validations of the diagram
+             */
+            initialize: function (attrs, options) {
+                this.draggedElement();
+                this.isActivated();
+                this.currentType();
+                this.invalid = false;
+            },
+            //keep the current dragged element type
+            currentType: function (type) {
+                if (_.isUndefined(type)) {
+                    return this.get('currentType');
+                } else {
+                    this.set('currentType', type);
+                }
+            },
+            draggedElement: function (element) {
+                if (_.isUndefined(element)) {
+                    return this.get('draggedElement');
+                } else {
+                    this.set('draggedElement', element);
+                }
+            },
+            // check the current activated element's valid drops
+            isActivated: function (activatedType) {
+                if (activatedType != null) {
+                    if (this.currentType() != "Resource" && this.currentType() != "EndPoint") {
+                        // validation for active endpoints
+                        if (activatedType.includes("EndPoint")) {
+                            this.invalid = true;
+                        }
+                        else {
+                            this.invalid = false;
+                        }
+                    }
+                }
+            }
+
+        });
+    models.EventManager = EventManager;
     models.DiagramElement = DiagramElement;
     models.DiagramElements = DiagramElements;
     models.Diagram = Diagram;

--- a/modules/sequence-diagram-editor/js/diagram/diagram-view.js
+++ b/modules/sequence-diagram-editor/js/diagram/diagram-view.js
@@ -898,6 +898,8 @@ var Diagrams = (function (diagrams) {
                 }
             },
             handleDropEvent: function (event, ui) {
+                // Check for invalid drops on endpoints
+                if(eventManager.invalid==false){
                 var newDraggedElem = $(ui.draggable).clone();
                 var txt = defaultView.model;
                 var id = ui.draggable.context.lastChild.id;
@@ -937,7 +939,7 @@ var Diagrams = (function (diagrams) {
                     txt.selectedNode.addChild(processor);
 
                     if (Processors.flowControllers[id].type == "ComplexProcessor") {
-                        (Processors.flowControllers[id].containableElements).forEach(function(elm) {
+                        (Processors.flowControllers[id].containableElements).forEach(function (elm) {
                             var containableProcessorElem = new SequenceD.Models.ContainableProcessorElement(lifeLineOptions);
                             containableProcessorElem.set('title', elm);
                             containableProcessorElem.parent(processor);
@@ -965,6 +967,7 @@ var Diagrams = (function (diagrams) {
                 } else {
 
                 }
+            } //for invalid check
             },
 
             render: function () {
@@ -992,7 +995,7 @@ var Diagrams = (function (diagrams) {
                 this.htmlDiv = $(this.options.selector);
                 this.htmlDiv.droppable({
                     drop: this.handleDropEvent,
-                    tolerance: "pointer"
+                    tolerance: "pointer",
                 });
 
 
@@ -1111,7 +1114,7 @@ var Diagrams = (function (diagrams) {
                     if(propertyPane) {
                         propertyPane.destroy();
                     }
-                    
+
                 } else if (!txt.model.selectedNode) {
                     if (selected.classList && selected.classList.contains("lifeline_selected")) {
                         selected.classList.toggle("lifeline_selected");

--- a/modules/sequence-diagram-editor/js/sequence_diagram/sequenced-view.js
+++ b/modules/sequence-diagram-editor/js/sequence_diagram/sequenced-view.js
@@ -624,11 +624,16 @@ var SequenceD = (function (sequenced) {
                      diagram = defaultView.model;
                     diagram.selectedNode = viewObj.model;
                     d3.select(this).style("fill", "green").style("fill-opacity", 0.1);
+                    // Update event manager with current active element type for validation
+                    eventManager.isActivated(diagram.selectedNode.attributes.title);
                 }).on('mouseout', function () {
                     diagram.destinationLifeLine = diagram.selectedNode;
                     diagram.selectedNode = null;
                     d3.select(this).style("fill-opacity", 0.01);
+                    // Update event manager with out of focus on active element
+                    eventManager.isActivated("none");
                 }).on('mouseup', function (data) {
+
                 });
 
                 drawMessageRect.on('mouseover', function () {
@@ -637,8 +642,12 @@ var SequenceD = (function (sequenced) {
                     diagram.selectedNode = viewObj.model;
                     d3.select(this).style("fill", "black").style("fill-opacity", 0.2)
                         .style("cursor", 'url(images/BlackHandwriting.cur), pointer');
+                    // Update event manager with current active element type for validation
+                    eventManager.isActivated(diagram.selectedNode.attributes.title);
                 }).on('mouseout', function () {
                     d3.select(this).style("fill-opacity", 0.0);
+                    // Update event manager with out of focus on active element
+                    eventManager.isActivated("none");
                 }).on('mouseup', function (data) {
                 });
 

--- a/modules/sequence-diagram-editor/js/tool-palette/tool-view.js
+++ b/modules/sequence-diagram-editor/js/tool-palette/tool-view.js
@@ -26,16 +26,18 @@ var Tools = (function (tools) {
 
         },
         handleOnDragEvent : function(event,ui){
-            var m = ui.helper;
-            var span = m[0].childNodes;
-            document.getElementById("validator").innerText="X";
-            document.getElementById("validator").style.width="70px";
-            document.getElementById("validator").style.display="none";
+            var helperElm = ui.helper;
+            var span = helperElm[0].childNodes;
+            var validator = document.getElementById("validator");
 
             //Visual feedback on invalid drops on endpoints
             if(eventManager.invalid){
-                document.getElementById("validator").style.display="block";
-                document.getElementById("validator").style.color="darkred";
+                validator.innerText="X";
+                validator.className = "tool-validator";
+                validator.style.display="block";
+            }
+            else{
+                validator.style.display="none";
             }
         },
 

--- a/modules/sequence-diagram-editor/js/tool-palette/tool-view.js
+++ b/modules/sequence-diagram-editor/js/tool-palette/tool-view.js
@@ -23,6 +23,27 @@ var Tools = (function (tools) {
 
         toolTemplate: _.template("<div id=\"<%=id%>\" class=\"tool-container\"> <img src=\"<%=icon%>\" class=\"tool-image\"  /><p class=\"tool-title\"><%=title%></p></div>"),
         handleDragStopEvent: function (event, ui) {
+
+        },
+        handleOnDragEvent : function(event,ui){
+            var m = ui.helper;
+            var span = m[0].childNodes;
+            document.getElementById("validator").innerText="X";
+            document.getElementById("validator").style.width="70px";
+            document.getElementById("validator").style.display="none";
+
+            //Visual feedback on invalid drops on endpoints
+            if(eventManager.invalid){
+                document.getElementById("validator").style.display="block";
+                document.getElementById("validator").style.color="darkred";
+            }
+        },
+
+        handleDragStartEvent : function(event,ui){
+            var elm = $(ui.draggable).clone();
+            eventManager.currentType(event.currentTarget.lastChild.id);
+            eventManager.draggedElement(elm);
+
         },
 
         initialize: function () {
@@ -42,7 +63,9 @@ var Tools = (function (tools) {
                 cursor: 'move',
                 cursorAt: _.isUndefined(dragCursorOffset) ?  { left: -2, top: -2 } : dragCursorOffset,
                 zIndex: 10001,
-                stop: this.handleDragStopEvent
+                stop: this.handleDragStopEvent,
+                start : this.handleDragStartEvent,
+                drag:this.handleOnDragEvent
             });
 
             return this;
@@ -51,6 +74,8 @@ var Tools = (function (tools) {
         createContainerForDraggable: function(){
             var body = d3.select("body");
             var div = body.append("div").attr("id", "draggingToolClone");
+            //For validation feedback
+            div.append('span').attr("id","validator");
             div =  D3Utils.decorate(div);
             return div;
         }


### PR DESCRIPTION
The current implementation of event manager validates where other elements cannot be dropped on endpoint elements. A visual feedback is provided when an element is dragged on top of an endpoint. 